### PR TITLE
Add download counters script

### DIFF
--- a/tools/download_counters/README.md
+++ b/tools/download_counters/README.md
@@ -1,0 +1,44 @@
+# Download Counters Script
+
+This script retrieves the download counts of a list of repositories from the GitHub API.
+
+## Prerequisites
+
+- Bash
+- `curl`
+- `jq` (for parsing JSON responses)
+
+## Setup
+
+1. Install `jq` if you don't have it already:
+
+   ```bash
+   sudo apt-get install jq
+   ```
+
+2. Obtain a GitHub personal access token with the `repo` or `public_repo` permission:
+
+   1. Go to [GitHub Personal Access Tokens](https://github.com/settings/tokens).
+   2. Click on **Generate new token**.
+   3. Give your token a descriptive name.
+   4. Select the `repo / public_repo` scope to grant the necessary permissions.
+   5. Click **Generate token**.
+   6. Copy the generated token and save it securely.
+
+## Usage
+
+1. Clone the repository or download the script.
+
+2. Open a terminal and navigate to the directory containing the script.
+
+3. Run the script:
+
+   ```bash
+   bash count.sh <github_token>
+   ```
+
+## Example
+
+```bash
+bash count.sh ghp_yourGitHubTokenHere
+```

--- a/tools/download_counters/count.sh
+++ b/tools/download_counters/count.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# List of repositories in the format owner/repo
+REPOS=(
+    "green-code-initiative/ecoCode-android"
+    "green-code-initiative/creedengo-csharp-sonarqube"
+    "green-code-initiative/creedengo-ios"
+    "green-code-initiative/creedengo-java"
+    "green-code-initiative/creedengo-javascript"
+    "green-code-initiative/creedengo-php"
+    "green-code-initiative/creedengo-python"
+)
+
+# Check if GitHub token is provided as an argument
+if [ -z "$1" ]; then
+  echo "Usage: $0 <github_token>"
+  exit 1
+fi
+
+GITHUB_TOKEN=$1
+
+# Function to get download counts for a repository
+get_download_counts() {
+  local repo=$1
+  local api_url="https://api.github.com/repos/$repo/releases"
+  
+  # Fetch releases data from GitHub API
+  response=$(curl -s -H "Authorization: token $GITHUB_TOKEN" $api_url)
+  
+  # Check if the response contains releases
+  if [[ $response == *"\"id\":"* ]]; then
+    # Extract download counts from the response
+    download_count=$(echo $response | jq '[.[] | .assets[].download_count] | add')
+    echo "Repository: $repo, Download Count: $download_count"
+  else
+    echo "Repository: $repo, No releases found or invalid repository."
+  fi
+}
+
+# Iterate over the list of repositories and get download counts
+for repo in "${REPOS[@]}"; do
+  get_download_counts $repo
+done


### PR DESCRIPTION
This pull request introduces a new script to retrieve the download counts of a list of repositories from the GitHub API. The changes include adding a README file with detailed instructions and the actual script to perform the download count retrieval.

Here is an example of what the script shows:
```
$ ./tools/download_counters/count.sh
Repository: green-code-initiative/ecoCode-android, Download Count: 2974
Repository: green-code-initiative/creedengo-csharp-sonarqube, Download Count: 1302
Repository: green-code-initiative/creedengo-ios, Download Count: 421
Repository: green-code-initiative/creedengo-java, Download Count: 14548
Repository: green-code-initiative/creedengo-javascript, Download Count: 12767
Repository: green-code-initiative/creedengo-php, Download Count: 5529
Repository: green-code-initiative/creedengo-python, Download Count: 12370
```

This is a first version which can be improved to see the detail by version for example.
And I can also propose a GitHub workflow to run the script from GitHub directly. Good idea?